### PR TITLE
Add PrimeNG theme and icon styles

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -26,6 +26,7 @@
               }
             ],
             "styles": [
+              "node_modules/primeicons/primeicons.css",
               "src/styles.css"
             ]
           },
@@ -79,6 +80,7 @@
               }
             ],
             "styles": [
+              "node_modules/primeicons/primeicons.css",
               "src/styles.css"
             ]
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@angular/forms": "^20.1.0",
         "@angular/platform-browser": "^20.1.0",
         "@angular/router": "^20.1.0",
+        "@primeng/themes": "^20.0.1",
         "chart.js": "^4.5.0",
         "primeicons": "^7.0.0",
         "primeng": "^20.0.1",
@@ -3152,6 +3153,16 @@
         "node": ">=14"
       }
     },
+    "node_modules/@primeng/themes": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/@primeng/themes/-/themes-20.0.1.tgz",
+      "integrity": "sha512-0Jf2nKm4O+tysDZXSj/rqX6Ff3LAK+f6v+wmu+jftIjedMPP6FBwgzGtw60Y5U8+oLs5gaq0A36XCvVaxN65uw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@primeuix/styled": "^0.7.1",
+        "@primeuix/themes": "^1.2.2"
+      }
+    },
     "node_modules/@primeuix/styled": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/@primeuix/styled/-/styled-0.7.2.tgz",
@@ -3168,6 +3179,15 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@primeuix/styles/-/styles-1.2.3.tgz",
       "integrity": "sha512-+KwmQsLTYgVAqFADmO252btz40lstPML6r4QMNjxz4gLNCKVW3kPR0/aCouQx6/21+boXG1P68tu8Zk3FAKr2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@primeuix/styled": "^0.7.2"
+      }
+    },
+    "node_modules/@primeuix/themes": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@primeuix/themes/-/themes-1.2.3.tgz",
+      "integrity": "sha512-GLAU2h6lhgln2w10EQalUQlgwbgQ0xZoIOLMNGfIvqU4O09L282P7rwKCKQksvAGAFt1GoO/Q1NgBSxnttr7iA==",
       "license": "MIT",
       "dependencies": {
         "@primeuix/styled": "^0.7.2"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@angular/forms": "^20.1.0",
     "@angular/platform-browser": "^20.1.0",
     "@angular/router": "^20.1.0",
+    "@primeng/themes": "^20.0.1",
     "chart.js": "^4.5.0",
     "primeicons": "^7.0.0",
     "primeng": "^20.0.1",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import '@primeng/themes/lara';
 import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app';


### PR DESCRIPTION
## Summary
- add PrimeNG Lora theme and primeicons styling
- register primeicons CSS in Angular configuration

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Module './admin' has no exported member 'Admin')*

------
https://chatgpt.com/codex/tasks/task_e_6897484850648322b2c629496b99d47c